### PR TITLE
Fix deprecation in failures crate

### DIFF
--- a/lesson-08/src/main.rs
+++ b/lesson-08/src/main.rs
@@ -143,7 +143,7 @@ pub fn failure_to_string(e: failure::Error) -> String {
 
     let mut result = String::new();
 
-    for (i, cause) in e.causes().collect::<Vec<_>>().into_iter().rev().enumerate() {
+    for (i, cause) in e.iter_chain().collect::<Vec<_>>().into_iter().rev().enumerate() {
         if i > 0 {
             let _ = writeln!(&mut result, "   Which caused the following issue:");
         }

--- a/lesson-09/src/main.rs
+++ b/lesson-09/src/main.rs
@@ -153,7 +153,7 @@ pub fn failure_to_string(e: failure::Error) -> String {
 
     let mut result = String::new();
 
-    for (i, cause) in e.causes().collect::<Vec<_>>().into_iter().rev().enumerate() {
+    for (i, cause) in e.iter_chain().collect::<Vec<_>>().into_iter().rev().enumerate() {
         if i > 0 {
             let _ = writeln!(&mut result, "   Which caused the following issue:");
         }

--- a/lesson-10/src/main.rs
+++ b/lesson-10/src/main.rs
@@ -137,7 +137,7 @@ pub fn failure_to_string(e: failure::Error) -> String {
 
     let mut result = String::new();
 
-    for (i, cause) in e.causes().collect::<Vec<_>>().into_iter().rev().enumerate() {
+    for (i, cause) in e.iter_chain().collect::<Vec<_>>().into_iter().rev().enumerate() {
         if i > 0 {
             let _ = writeln!(&mut result, "   Which caused the following issue:");
         }

--- a/lesson-11/src/main.rs
+++ b/lesson-11/src/main.rs
@@ -148,7 +148,7 @@ pub fn failure_to_string(e: failure::Error) -> String {
 
     let mut result = String::new();
 
-    for (i, cause) in e.causes().collect::<Vec<_>>().into_iter().rev().enumerate() {
+    for (i, cause) in e.iter_chain().collect::<Vec<_>>().into_iter().rev().enumerate() {
         if i > 0 {
             let _ = writeln!(&mut result, "   Which caused the following issue:");
         }

--- a/lesson-12/src/main.rs
+++ b/lesson-12/src/main.rs
@@ -131,7 +131,7 @@ pub fn failure_to_string(e: failure::Error) -> String {
 
     let mut result = String::new();
 
-    for (i, cause) in e.causes().collect::<Vec<_>>().into_iter().rev().enumerate() {
+    for (i, cause) in e.iter_chain().collect::<Vec<_>>().into_iter().rev().enumerate() {
         if i > 0 {
             let _ = writeln!(&mut result, "   Which caused the following issue:");
         }

--- a/lesson-13/src/debug.rs
+++ b/lesson-13/src/debug.rs
@@ -5,7 +5,7 @@ pub fn failure_to_string(e: failure::Error) -> String {
 
     let mut result = String::new();
 
-    for (i, cause) in e.causes().collect::<Vec<_>>().into_iter().rev().enumerate() {
+    for (i, cause) in e.iter_chain().collect::<Vec<_>>().into_iter().rev().enumerate() {
         if i > 0 {
             let _ = writeln!(&mut result, "   Which caused the following issue:");
         }

--- a/lesson-14-x/src/debug.rs
+++ b/lesson-14-x/src/debug.rs
@@ -5,7 +5,7 @@ pub fn failure_to_string(e: failure::Error) -> String {
 
     let mut result = String::new();
 
-    for (i, cause) in e.causes().collect::<Vec<_>>().into_iter().rev().enumerate() {
+    for (i, cause) in e.iter_chain().collect::<Vec<_>>().into_iter().rev().enumerate() {
         if i > 0 {
             let _ = writeln!(&mut result, "   Which caused the following issue:");
         }

--- a/lesson-15-x/src/debug.rs
+++ b/lesson-15-x/src/debug.rs
@@ -5,7 +5,7 @@ pub fn failure_to_string(e: failure::Error) -> String {
 
     let mut result = String::new();
 
-    for (i, cause) in e.causes().collect::<Vec<_>>().into_iter().rev().enumerate() {
+    for (i, cause) in e.iter_chain().collect::<Vec<_>>().into_iter().rev().enumerate() {
         if i > 0 {
             let _ = writeln!(&mut result, "   Which caused the following issue:");
         }

--- a/lesson-16-x/src/debug.rs
+++ b/lesson-16-x/src/debug.rs
@@ -5,7 +5,7 @@ pub fn failure_to_string(e: failure::Error) -> String {
 
     let mut result = String::new();
 
-    for (i, cause) in e.causes().collect::<Vec<_>>().into_iter().rev().enumerate() {
+    for (i, cause) in e.iter_chain().collect::<Vec<_>>().into_iter().rev().enumerate() {
         if i > 0 {
             let _ = writeln!(&mut result, "   Which caused the following issue:");
         }

--- a/lesson-17-x/src/debug.rs
+++ b/lesson-17-x/src/debug.rs
@@ -5,7 +5,7 @@ pub fn failure_to_string(e: failure::Error) -> String {
 
     let mut result = String::new();
 
-    for (i, cause) in e.causes().collect::<Vec<_>>().into_iter().rev().enumerate() {
+    for (i, cause) in e.iter_chain().collect::<Vec<_>>().into_iter().rev().enumerate() {
         if i > 0 {
             let _ = writeln!(&mut result, "   Which caused the following issue:");
         }

--- a/lesson-18-x/src/debug.rs
+++ b/lesson-18-x/src/debug.rs
@@ -5,7 +5,7 @@ pub fn failure_to_string(e: failure::Error) -> String {
 
     let mut result = String::new();
 
-    for (i, cause) in e.causes().collect::<Vec<_>>().into_iter().rev().enumerate() {
+    for (i, cause) in e.iter_chain().collect::<Vec<_>>().into_iter().rev().enumerate() {
         if i > 0 {
             let _ = writeln!(&mut result, "   Which caused the following issue:");
         }

--- a/lesson-19-x/src/debug.rs
+++ b/lesson-19-x/src/debug.rs
@@ -5,7 +5,7 @@ pub fn failure_to_string(e: failure::Error) -> String {
 
     let mut result = String::new();
 
-    for (i, cause) in e.causes().collect::<Vec<_>>().into_iter().rev().enumerate() {
+    for (i, cause) in e.iter_chain().collect::<Vec<_>>().into_iter().rev().enumerate() {
         if i > 0 {
             let _ = writeln!(&mut result, "   Which caused the following issue:");
         }

--- a/lesson-20-x/src/debug.rs
+++ b/lesson-20-x/src/debug.rs
@@ -5,7 +5,7 @@ pub fn failure_to_string(e: failure::Error) -> String {
 
     let mut result = String::new();
 
-    for (i, cause) in e.causes().collect::<Vec<_>>().into_iter().rev().enumerate() {
+    for (i, cause) in e.iter_chain().collect::<Vec<_>>().into_iter().rev().enumerate() {
         if i > 0 {
             let _ = writeln!(&mut result, "   Which caused the following issue:");
         }

--- a/lesson-21-x/src/debug.rs
+++ b/lesson-21-x/src/debug.rs
@@ -5,7 +5,7 @@ pub fn failure_to_string(e: failure::Error) -> String {
 
     let mut result = String::new();
 
-    for (i, cause) in e.causes().collect::<Vec<_>>().into_iter().rev().enumerate() {
+    for (i, cause) in e.iter_chain().collect::<Vec<_>>().into_iter().rev().enumerate() {
         if i > 0 {
             let _ = writeln!(&mut result, "   Which caused the following issue:");
         }

--- a/lesson-22-x/src/debug.rs
+++ b/lesson-22-x/src/debug.rs
@@ -5,7 +5,7 @@ pub fn failure_to_string(e: failure::Error) -> String {
 
     let mut result = String::new();
 
-    for (i, cause) in e.causes().collect::<Vec<_>>().into_iter().rev().enumerate() {
+    for (i, cause) in e.iter_chain().collect::<Vec<_>>().into_iter().rev().enumerate() {
         if i > 0 {
             let _ = writeln!(&mut result, "   Which caused the following issue:");
         }

--- a/lesson-23-x/src/debug.rs
+++ b/lesson-23-x/src/debug.rs
@@ -5,7 +5,7 @@ pub fn failure_to_string(e: failure::Error) -> String {
 
     let mut result = String::new();
 
-    for (i, cause) in e.causes().collect::<Vec<_>>().into_iter().rev().enumerate() {
+    for (i, cause) in e.iter_chain().collect::<Vec<_>>().into_iter().rev().enumerate() {
         if i > 0 {
             let _ = writeln!(&mut result, "   Which caused the following issue:");
         }

--- a/lesson-24-x/src/debug.rs
+++ b/lesson-24-x/src/debug.rs
@@ -5,7 +5,7 @@ pub fn failure_to_string(e: failure::Error) -> String {
 
     let mut result = String::new();
 
-    for (i, cause) in e.causes().collect::<Vec<_>>().into_iter().rev().enumerate() {
+    for (i, cause) in e.iter_chain().collect::<Vec<_>>().into_iter().rev().enumerate() {
         if i > 0 {
             let _ = writeln!(&mut result, "   Which caused the following issue:");
         }


### PR DESCRIPTION
Noticed this when compiling with the latest `failures` crate:
```
warning: use of deprecated item 'failure::Error::causes': please use the 'iter_chain()' method instead
 --> lesson-13/src/debug.rs:8:25
  |
8 |     for (i, cause) in e.causes().collect::<Vec<_>>().into_iter().rev().enumerate() {
  |                         ^^^^^^
  |
  = note: #[warn(deprecated)] on by default
```